### PR TITLE
main: add ability to skip photos and/or videos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "fb-unarchive"
-version = "0.1.0"
+version = "0.2.0-dev"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Skip videos by default. There are videos in the photos list and they
cause the following error.

Error: Failed to parse blah.mp4 first two bytes is not a SOI marker