### PR TITLE
github: fix cargo fmt check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - uses: mbrobbel/rustfmt-check@master
+      - uses: actions-rs/cargo@v1
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          command: fmt
 
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I'm not sure what's going on with mbrobbel/rustfmt-check, but it keeps
failing with the following:

     ##[error]Cannot read property 'payload' of undefined

Since I'm not actually interested in the auto-commit functionality of
mbrobbel/rustfmt-check, it makes sense just to call `cargo fmt`
directly.